### PR TITLE
Use nokotime.com as API host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-Node.js freckle api bindings
-============================
+Node.js Freckle/Noko api bindings
+=================================
 
 Created by Tim Branyen [@tbranyen](http://twitter.com/tbranyen)
 
-These bindings work specifically with the Freckle V1 API.  If you are not currently using Freckle for
-time management, you totally should! It rocks! http://letsfreckle.com, it was created by @madrobby who
+These bindings work specifically with the Noko (formally Freckle) V1 API.  If you are not currently using Noko for
+time management, you totally should! It rocks! https://nokotime.com, it was created by @madrobby who
 has been excellent with his support.
+
+Note: Freckle was renamed to Noko in Q2/2019. Any references to Freckle or Noko are the same.
 
 Installing
 -----------------------

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ module.exports = function() {
     };
 
     self.settings = {
-        host: "letsfreckle.com",
+        host: "nokotime.com",
         path: "/api/",
         subdomain: "apitest",
         port: 443,
@@ -99,7 +99,7 @@ module.exports = function() {
 
             // wrap http call for automatic pagination
             var paginated_http_call = function(options, tmp) {
-                
+
                 var req = https.request(options, function(res) {
                     var ret = '';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freckle"
-, "description": "Node.js freckle api bindings"
-, "version": "0.0.1"
+, "description": "Node.js Freckle/Noko api bindings"
+, "version": "0.0.2"
 , "author": "Tim Branyen <tim@tabdeveloper.com> (http://twitter.com/tbranyen)"
 , "main": "./lib/index.js"
 , "directories": {


### PR DESCRIPTION
This updates the codebase to use the new name "Noko" for the app
formally known as Freckle. There's only one change: a new domain name
for the API calls.

**PLEASE NOTE: This new domain will come online March 25, 2019. DO NOT MERGE THIS PR BEFORE THAT DATE.**

See https://letsfreckle.com/blog/2019/03/freckle-getting-new-name-noko/ for more info on the rename.